### PR TITLE
CICD status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CICD Status](https://github.com/UCL-CCS/Nbed/actions/workflows/release.yaml/badge.svg?branch=master)](https://github.com/UCL-CCS/Nbed/actions/workflows/release.yaml) [![Documentation Status](https://readthedocs.org/projects/nbed/badge/?version=latest)](https://nbed.readthedocs.io/en/latest/?badge=latest) [![DOI](https://zenodo.org/badge/341631818.svg)](https://zenodo.org/badge/latestdoi/341631818)
+[![Master CICD](https://github.com/UCL-CCS/Nbed/actions/workflows/push_to_master.yaml/badge.svg)](https://github.com/UCL-CCS/Nbed/actions/workflows/push_to_master.yaml) [![Documentation Status](https://readthedocs.org/projects/nbed/badge/?version=latest)](https://nbed.readthedocs.io/en/latest/?badge=latest) [![DOI](https://zenodo.org/badge/341631818.svg)](https://zenodo.org/badge/latestdoi/341631818)
 
 
 


### PR DESCRIPTION
badge previously tracked release, for which there was no data

now points at 'merge into master' workflow.