### PR TITLE
updated paths to water.xyz file in notebooks 1,2,6

### DIFF
--- a/docs/notebooks/2. Orbital Localization Functions.ipynb
+++ b/docs/notebooks/2. Orbital Localization Functions.ipynb
@@ -185,15 +185,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
     "# get xyz file for water\n",
     "\n",
     "notebook_dir = os.getcwd()\n",
-    "source_dir = os.path.dirname(notebook_dir)\n",
-    "docs_dir = os.path.dirname(source_dir)\n",
+    "docs_dir = os.path.dirname(notebook_dir)\n",
     "NBed_dir = os.path.dirname(docs_dir)\n",
     "Test_dir = os.path.join(NBed_dir, 'tests')\n",
     "mol_dir = os.path.join(Test_dir, 'molecules')\n",
@@ -203,16 +202,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "-74.96445640381192"
+       "-74.9644564039415"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -527,7 +526,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/6. Long form Notes.ipynb
+++ b/docs/notebooks/6. Long form Notes.ipynb
@@ -5,7 +5,18 @@
    "execution_count": 1,
    "id": "8ae5bba2",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/tom/Library/Caches/pypoetry/virtualenvs/nbed-qTNLV2g4-py3.8/lib/python3.8/site-packages/_distutils_hack/__init__.py:33: UserWarning: Setuptools is replacing distutils.\n",
+      "  warnings.warn(\"Setuptools is replacing distutils.\")\n",
+      "/Users/tom/Library/Caches/pypoetry/virtualenvs/nbed-qTNLV2g4-py3.8/lib/python3.8/site-packages/pyscf/dft/libxc.py:772: UserWarning: Since PySCF-2.3, B3LYP (and B3P86) are changed to the VWN-RPA variant, the same to the B3LYP functional in Gaussian and ORCA (issue 1480). To restore the VWN5 definition, you can put the setting \"B3LYP_WITH_VWN5 = True\" in pyscf_conf.py\n",
+      "  warnings.warn('Since PySCF-2.3, B3LYP (and B3P86) are changed to the VWN-RPA variant, '\n"
+     ]
+    }
+   ],
    "source": [
     "import os\n",
     "from nbed.driver import NbedDriver\n",
@@ -36,8 +47,7 @@
     "# get xyz file for water\n",
     "\n",
     "notebook_dir = os.getcwd()\n",
-    "source_dir = os.path.dirname(notebook_dir)\n",
-    "docs_dir = os.path.dirname(source_dir)\n",
+    "docs_dir = os.path.dirname(notebook_dir)\n",
     "NBed_dir = os.path.dirname(docs_dir)\n",
     "Test_dir = os.path.join(NBed_dir, 'tests')\n",
     "mol_dir = os.path.join(Test_dir, 'molecules')\n",
@@ -2580,7 +2590,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixes incorrect path to `water.xyz` file in jupyter notebooks 1, 2, 6 (issue number #106).

This was done by removing `source_dir = os.path.dirname(notebook_dir)`,

And replacing `docs_dir = os.path.dirname(source_dir)` with `docs_dir = os.path.dirname(notebook_dir)`.

This was done in all three notebooks that use the `water.xyz` file.