### PR TITLE
bump version to 0.0.2

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ['3.8','3.11']
+        python-version: ['3.8','3.10']
     steps:
       - uses: actions/checkout@v2
       - name: Set up python

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.0.2]
 ### Fixed
 - Typo with the license file, which was called 'LISENCE' instead of 'LICENSE'.
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,6 +8,6 @@ authors:
     given-names: Alexis
     orcid: https://orcid.org/0000-0001-8953-1235
 title: "Nbed"
-version: 0.0.1
+version: 0.0.2
 date-released: 2022-03-07
 doi: 10.5281/zenodo.6323338

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,7 +24,7 @@ copyright = "2022, Michael Williams, Alexis Ralli"
 author = "Michael Williams, Alexis Ralli"
 
 # The full version, including alpha/beta/rc tags
-release = "0.0.1"
+release = "0.0.2"
 
 
 # -- General configuration ---------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nbed"
-version = "0.0.1"
+version = "0.0.2"
 description = ""
 authors = ["Michael Williams <michael.williams.20@ucl.ac.uk>"]
 
@@ -47,6 +47,7 @@ sphinx-rtd-theme = "^1.0.0"
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+
 
 
 [tool.poetry.scripts]


### PR DESCRIPTION
Changes the version information to 0.0.2.

- [x] Changelog up to date
- [ ] CICD Passing
- [x] Tested publish with PyPI Test

After merge:

- [ ] create tag
- [ ] publish to pypi