### PR TITLE
Bump to version 0.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.0.3]
 ### Fixed
 - Correct error in embedded CCSD energy.
 - Correct error in driver for calculating e_act
 
 ### Changed
 - tests now use `b3lyp5` functional to match those in v1 before PySCF update.
+- Dependencies updated to enable pypi install on Apple Silicon devices.
 
 ### Added
 - Function to convert Symmer PualiwordOp to openfermion faster (to be removed when updated symmer is released)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nbed"
-version = "0.0.2"
+version = "0.0.3"
 description = ""
 authors = ["Michael Williams <michael.williams.20@ucl.ac.uk>"]
 
@@ -47,6 +47,7 @@ sphinx-rtd-theme = "^1.0.0"
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+
 
 
 [tool.poetry.scripts]


### PR DESCRIPTION
- Dependencies updated to allow Apple Silicon install from pypi
- Corrected bugs which were giving incorrect energy results
- `notebooks/publications` folder for reproducability